### PR TITLE
Fix for page not found error on click of read more 

### DIFF
--- a/app/pods/courses/template.hbs
+++ b/app/pods/courses/template.hbs
@@ -91,7 +91,7 @@
               Chatbots
               Deployment & System Adminstration
               LIVE Project & Hackathon</p>
-            <p><a href="https://www.codingblocks.com/courses/django.html" class="btn btn-raised waves-effect btn-sm" role="button" target="_blank">Read more</a> </p>
+            <!--<p><a href="https://www.codingblocks.com/courses/django.html" class="btn btn-raised waves-effect btn-sm" role="button" target="_blank">Read more</a> </p>-->
           </div>
         </div>
       </div>


### PR DESCRIPTION
On click of read more of Django, page not found error is coming. So commented out the link as there is no page named
https://www.codingblocks.com/courses/django.html exists in codingblocks/courses.