### PR TITLE
if oneaouth id is returned by backend show it else don't

### DIFF
--- a/app/pods/users/user/template.hbs
+++ b/app/pods/users/user/template.hbs
@@ -14,7 +14,9 @@
                                     alt=""> {{/if}}
                             </div>
                             <h4><strong>{{user.name}}</strong></h4>
-                            <h5>CodingBlocks Id: {{user.oauthId}}</h5>
+                            {{#if user.oauthId}}
+                              <h5>CodingBlocks Id: {{user.oauthId}}</h5>
+                            {{/if}}
                         </div>
                     </div>
                     <div class="profile-sub-header">


### PR DESCRIPTION
users/me brings oneauthid but /users/:userid doesn't.
@witty123  please review and merge