### PR TITLE
rendered html instead of raw markdown.

### DIFF
--- a/app/pods/components/current-cb-card/template.hbs
+++ b/app/pods/components/current-cb-card/template.hbs
@@ -8,7 +8,7 @@
             <div class="row">
               <div class="col-lg-6 col-md-6 col-sm-8 col-xs-12">
                 <div class="row daily-problem-div">
-                  <p id="daily-problem-description" class="para">{{dailycb.problem.content.content.description}}</p>
+                  <p id="daily-problem-description" class="para">{{markdown-to-html dailycb.problem.content.content.description}}</p>
                 </div>
 
                   {{#each dailycb.problem.tags as |tag|}}


### PR DESCRIPTION
Screenshots of rendered html to markdown in various screen sizes.
![screen shot 2018-02-06 at 11 30 00 pm](https://user-images.githubusercontent.com/8257951/35875603-d1fb8144-0b95-11e8-87b4-a0cb7ddedfd1.png)
![screen shot 2018-02-06 at 11 30 04 pm](https://user-images.githubusercontent.com/8257951/35875604-d246c988-0b95-11e8-9082-9f2357417fe7.png)
![screen shot 2018-02-06 at 11 30 12 pm](https://user-images.githubusercontent.com/8257951/35875605-d289b720-0b95-11e8-8c67-f13032355cc1.png)
