### PR TITLE
Corrected menu-bar position misaligned

### DIFF
--- a/vendor/css/all-themes.css
+++ b/vendor/css/all-themes.css
@@ -200,8 +200,7 @@
     width: 32px;
     height: 32px;
     position: absolute;
-    right:0px;
-	cursor: pointer;
+	  cursor: pointer;
     display: inline-block !important;
     padding: 9px 8px 8px 9px;
 }


### PR DESCRIPTION
Fixes #191

Corrected menu-bar position misaligned
Updated  vendor/css/all-themes.css for correcting the same
